### PR TITLE
change url of bookmarklet script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Audit the CSS on a page to see what elements are using styles from the style guide and which styles are overriding them.
 
+**IMPORTANT: Dropbox changed how their Public folder worked and removed all previous links to files hosted in it (which is where the Bookmarklet script is kept). All previous versions (1.0.1 and below) of the bookmarklet will no longer work until you've updated to the latest code.**
+
 ## How it works
 
 The code parses all the style sheets on the page and keeps track of every rule and how it affects all elements. When you run the audit, it takes this information and looks at which rules from other style sheets are overriding the rules from the style guide. Any elements that have an override are highlighted.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-style-guide-audit",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Audit the CSS on a page to ensure that no other styles are overriding the pattern library's styles",
   "main": "index.js",
   "scripts": {

--- a/src/bookmarkletCore.js
+++ b/src/bookmarkletCore.js
@@ -11,5 +11,5 @@ script.onload = function() {
   parseStyleSheets();
 };
 
-script.src = 'https://dl.dropboxusercontent.com/u/22115399/index-1.0.1.min.js';
+script.src = 'https://www.dropbox.com/s/vs4ny7igudc23jb/index-1.0.1.min.js?dl=0&raw=1';
 document.head.appendChild(script);


### PR DESCRIPTION
Dropbox [changed their policy on their Public folder](https://www.dropbox.com/help/16), forcing me to wait until the change occurred before I could create a shared link to the file to use in the bookmarklet.